### PR TITLE
#44 デイリーランキングが表示されない問題の修正

### DIFF
--- a/application/score.php
+++ b/application/score.php
@@ -38,7 +38,7 @@ function getRanking($pdo, $rankingType, $score = -1) {
   switch ($rankingType) {
     case RANKING_TYPE_DAILY:
       // リセット時間が 5:00 JST = -4:00 UTC
-      $where = "created_at > datetime(CURRENT_TIMESTAMP, '+' || :resetHour || ' hours', 'start of day', '+' || :resetHour || ' hours')";
+      $where = "created_at > datetime(CURRENT_TIMESTAMP, '+' || :resetHour || ' hours', 'start of day', '-' || :resetHour || ' hours')";
       $binds['resetHour'] = ['value' => $resetHour, 'type' => PDO::PARAM_INT];
       break;
 


### PR DESCRIPTION
-が+になっていた…

その他

* エッジケースでひったりな時間が含まれていなかった(そっちのほうが自然な気がしたので)
* テストできるように現在時刻をだした。

PHPUnit入れようかと思ったけど、サイト上の配置が謎だったので何がpublicに出てしまうかわからないので考えないことにした（
今だとランキングファイルとか取れちゃってる。
  